### PR TITLE
Query RPC up to 50 times to find oldest wallet tx

### DIFF
--- a/src/discord-user/discordUser.service.ts
+++ b/src/discord-user/discordUser.service.ts
@@ -26,7 +26,7 @@ type PublicKeyStrObj = { publicKeyStr: string };
 
 const HELIUS_BASE_URL = 'https://api.helius.xyz/v0';
 const MINIMUM_SOL = 0.1;
-const MAX_TXS_TO_SCAN = 10000;
+const MAX_TXS_TO_SCAN = 50_000;
 
 function delay(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));


### PR DESCRIPTION
Some users have scripted wallet they want to verify with.

50k takes like 1 minute with helius RPC endpoint, and should satisfy a long tail of developer users.