### PR TITLE
Matchday fix

### DIFF
--- a/src/discord-user/matchdayDiscordUser.service.ts
+++ b/src/discord-user/matchdayDiscordUser.service.ts
@@ -79,7 +79,6 @@ export class MatchdayDiscordUserService {
     ).json();
 
     const { twitterFollow, matchdayUsername, userName } = matchdayResponse.data;
-    console.info({ d: matchdayResponse.data });
 
     // twitterFollow == true and the existence of the username mean both a Twitter follow and Discord connection
     return { matchdayUsername, socialFollow: twitterFollow && !!userName };


### PR DESCRIPTION
both `twitterFollow` and `userName` (which represents Discord connect) both should be true for this boolean to be true. 

the registered metadata already reflects that this is should be both Twitter + Discord connect