### PR TITLE
Updating Matchday Challenge Pass collection id

### DIFF
--- a/src/discord-user/matchdayDiscordUser.service.ts
+++ b/src/discord-user/matchdayDiscordUser.service.ts
@@ -9,7 +9,7 @@ import { MatchdayDiscordUser } from './entities/MatchdayDiscordUser.entity';
 
 // You figure this ID out by passing a Solana NFT into this API: https://simplehash.readme.io/reference/nft-by-token_id-1
 // and seeing what collection id gets returned
-const SIMPLEHASH_CHALLENGE_PASS_COLLECTION_ID = '220efa958c716cd8ad1788d07861e511';
+const SIMPLEHASH_CHALLENGE_PASS_COLLECTION_ID = '12ad92a4cf8347afe051326ddd7e439a';
 
 function delay(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));


### PR DESCRIPTION
not 100% sure what happened here, but the previous SimpleHash collection id references a set of Matchday Challenge Passes that has since been burned—this collection id is the correct one

you can verify by going to [this page](https://docs.simplehash.com/reference/nfts-by-collection) and adding the collection id: `12ad92a4cf8347afe051326ddd7e439a` and see NFTs like [this](https://explorer.solana.com/address/127bRqRLWUhgN9K6pBouB2hG9QcCyj1SnuSDQB4GLnZi) show up